### PR TITLE
feat(scraper): add keydown event to trigger loading of lazy loading ressources

### DIFF
--- a/components/ecoindex/scraper/scrap.py
+++ b/components/ecoindex/scraper/scrap.py
@@ -82,6 +82,7 @@ class EcoindexScraper:
             await self.page.wait_for_load_state()
             sleep(self.wait_before_scroll)
             await self.generate_screenshot()
+            await self.page.keyboard.press('ArrowDown')
             await self.page.evaluate(
                 "window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })"
             )


### PR DESCRIPTION
Some lazyloading librairies trigger the loading of ressources only when a "human" action is perform. 
For exemple wp-rocket triggers on these events : "keydown","mousedown","mousemove","touchmove","touchstart","touchend","wheel"

Lazy loading is a good practice but to ensure that the eco-index work as intended we need to load all ressources. 

This PR adds a keydown event to the playwright process.