### PR TITLE
fix(scrapper): manage audio and video requests

### DIFF
--- a/components/ecoindex/scraper/scrap.py
+++ b/components/ecoindex/scraper/scrap.py
@@ -131,10 +131,10 @@ class EcoindexScraper:
                 else:
                     size = entry["response"]["_transferSize"]
                     if size == -1:
-                        request_headers_size = len(
+                        response_headers_size = len(
                             json.dumps(entry["response"]).encode("utf-8")
                         )
-                        size = request_headers_size
+                        size = response_headers_size
 
                 aggregation[category]["total_size"] += size
                 self.all_requests.total_count += 1

--- a/components/ecoindex/scraper/scrap.py
+++ b/components/ecoindex/scraper/scrap.py
@@ -157,7 +157,7 @@ class EcoindexScraper:
             )
         headers = response.headers
         content_type = next((value for key, value in headers.items() if key.lower() == 'content-type'), None)
-        if content_type and content_type != "text/html":
+        if content_type and "text/html" not in content_type:
             raise TypeError(
                 {
                     "mimetype": content_type,

--- a/test/components/ecoindex/scraper/test_scraper.py
+++ b/test/components/ecoindex/scraper/test_scraper.py
@@ -1,3 +1,4 @@
+import json
 from ecoindex.models import ScreenShot, WindowSize
 from ecoindex.scraper import EcoindexScraper
 
@@ -45,3 +46,77 @@ def test_scraper_init_with_options():
     assert scraper.screenshot.get_webp() == f"{screenshot_folder}/{screenshot_id}.webp"  # type: ignore
     assert scraper.screenshot_gid == screenshot_gid
     assert scraper.page_load_timeout == page_load_timeout
+
+
+def test_get_request_size():
+    mock_stripped_har_entry = (
+        {
+            "request": {
+                "url": "https://www.ecoindex.fr/",
+            },
+            "response": {
+                "status": 200,
+                "headers": [
+                    {"name": "content-length", "value": "7347"},
+                ],
+                "content": {
+                    "mimeType": "text/html",
+                },
+                "_transferSize": 7772,
+            },
+        },
+        {
+            "request": {
+                "url": "https://www.ecoindex.fr/",
+            },
+            "response": {
+                "status": 200,
+                "headers": [
+                    {"name": "content-length", "value": "7347"},
+                ],
+                "content": {
+                    "mimeType": "text/html",
+                },
+                "_transferSize": -1,
+            },
+        },
+         {
+            "request": {
+                "url": "https://www.ecoindex.fr/",
+            },
+            "response": {
+                "status": 206,
+                "headers": [
+                    {"name": "Content-Length", "value": "7347"},
+                ],
+                "content": {
+                    "mimeType": "text/html",
+                },
+                "_transferSize": -1,
+            },
+        },
+    )
+    url = "https://www.example.com"
+    window_size = WindowSize(width=800, height=600)
+    wait_before_scroll = 2
+    wait_after_scroll = 2
+    screenshot_uid = 123
+    screenshot_gid = 456
+    page_load_timeout = 30
+    screenshot_id = "123"
+    screenshot_folder = "/tmp/screenshots"
+
+    scraper = EcoindexScraper(
+        url=url,  # type: ignore
+        window_size=window_size,
+        wait_before_scroll=wait_before_scroll,
+        wait_after_scroll=wait_after_scroll,
+        screenshot=ScreenShot(id=screenshot_id, folder=screenshot_folder),
+        screenshot_uid=screenshot_uid,
+        screenshot_gid=screenshot_gid,
+        page_load_timeout=page_load_timeout,
+    )
+    assert scraper.get_request_size("text", mock_stripped_har_entry[0]) == 7772
+    assert scraper.get_request_size("text", mock_stripped_har_entry[1]) == len(json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8"))
+    assert scraper.get_request_size("audio", mock_stripped_har_entry[1]) == len(json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8"))
+    assert scraper.get_request_size("audio", mock_stripped_har_entry[2]) == 7347

--- a/test/components/ecoindex/scraper/test_scraper.py
+++ b/test/components/ecoindex/scraper/test_scraper.py
@@ -1,4 +1,5 @@
 import json
+from ecoindex.exceptions.scraper import EcoindexScraperStatusException
 from ecoindex.models import ScreenShot, WindowSize
 from ecoindex.scraper import EcoindexScraper
 
@@ -80,7 +81,7 @@ def test_get_request_size():
                 "_transferSize": -1,
             },
         },
-         {
+        {
             "request": {
                 "url": "https://www.ecoindex.fr/",
             },
@@ -116,7 +117,76 @@ def test_get_request_size():
         screenshot_gid=screenshot_gid,
         page_load_timeout=page_load_timeout,
     )
-    assert scraper.get_request_size("text", mock_stripped_har_entry[0]) == 7772
-    assert scraper.get_request_size("text", mock_stripped_har_entry[1]) == len(json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8"))
-    assert scraper.get_request_size("audio", mock_stripped_har_entry[1]) == len(json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8"))
-    assert scraper.get_request_size("audio", mock_stripped_har_entry[2]) == 7347
+    assert scraper.get_request_size(mock_stripped_har_entry[0]) == 7772
+    assert scraper.get_request_size(mock_stripped_har_entry[1]) == len(
+        json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8")
+    )
+    assert scraper.get_request_size(mock_stripped_har_entry[1]) == len(
+        json.dumps(mock_stripped_har_entry[1]["response"]).encode("utf-8")
+    )
+    assert scraper.get_request_size(mock_stripped_har_entry[2]) == 7347
+
+
+async def test_check_page_response():
+    mock_stripped_har_entry = (
+        {
+            "response": {
+                "status": 200,
+                "headers": {"content-type": "audio/mpeg"},
+            }
+        },
+        {
+            "response": {
+                "status": 404,
+                "headers": {"content-type": "text/html"},
+                "status_text": "Not Found",
+            }
+        },
+        {
+            "response": {
+                "status": 200,
+                "headers": {"content-type": "text/html"},
+            }
+        },
+    )
+    url = "https://www.example.com"
+    window_size = WindowSize(width=800, height=600)
+    wait_before_scroll = 2
+    wait_after_scroll = 2
+    screenshot_uid = 123
+    screenshot_gid = 456
+    page_load_timeout = 30
+    screenshot_id = "123"
+    screenshot_folder = "/tmp/screenshots"
+
+    scraper = EcoindexScraper(
+        url=url,  # type: ignore
+        window_size=window_size,
+        wait_before_scroll=wait_before_scroll,
+        wait_after_scroll=wait_after_scroll,
+        screenshot=ScreenShot(id=screenshot_id, folder=screenshot_folder),
+        screenshot_uid=screenshot_uid,
+        screenshot_gid=screenshot_gid,
+        page_load_timeout=page_load_timeout,
+    )
+    try:
+        scraper.check_page_response(mock_stripped_har_entry[0])
+    except TypeError as e:
+        assert str(e) == {
+            "mimetype": "audio/mpeg",
+            "message": (
+                "This resource is not "
+                "a standard page with mimeType 'text/html'"
+            ),
+        }
+
+    try:
+        scraper.check_page_response(mock_stripped_har_entry[1])
+    except EcoindexScraperStatusException as e:
+        assert str(e) == {
+            "url": "https://www.example.com",
+            "status": 404,
+            "message": mock_stripped_har_entry[1]["response"]["status_text"],
+        }
+    
+    assert scraper.check_page_response(mock_stripped_har_entry[2]) is None


### PR DESCRIPTION
Modify get_requests_from_har_file method to take into account mp3 and audio requests. 

Basically manage cases when _transferSize in the HTTP request is equal to -1.

close #30 