### PR TITLE
Fix repository URLs & uniformisation

### DIFF
--- a/projects/ecoindex_api/pyproject.toml
+++ b/projects/ecoindex_api/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "ecoindex_api"
 version = "3.11.1"
+readme = "README.md"
 description = "REST API to expose Ecoindex"
 authors = ['Vincent Vatelot <vincent.vatelot@ik.me>']
 license = "Creative Commons BY-NC-ND"
 homepage = "http://www.ecoindex.fr"
-repository = "https://github.com/cnumr/ecoindex_api"
+repository = "https://github.com/cnumr/EcoIndex_python"
 include = ["LICENSE"]
-
 packages = [
     { include = "ecoindex/backend", from = "../../bases" },
     { include = "ecoindex/compute", from = "../../components" },

--- a/projects/ecoindex_cli/pyproject.toml
+++ b/projects/ecoindex_cli/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "ecoindex_cli"
 version = "2.30.0"
+readme = "README.md"
 description = "`ecoindex-cli` is a CLI tool that let you make ecoindex tests on given pages"
 authors = ['Vincent Vatelot <vincent.vatelot@ik.me>']
 license = "Creative Commons BY-NC-ND"
-readme = "README.md"
 homepage = "http://www.ecoindex.fr"
-repository = "https://github.com/cnumr/ecoindex_cli"
+repository = "https://github.com/cnumr/EcoIndex_python"
 include = ["LICENSE"]
 packages = [
     { include = "ecoindex/cli", from = "../../bases" },
@@ -30,7 +30,7 @@ playwright = "^1.39.0"
 playwright-stealth = "^1.0.6"
 pydantic = "^2.4.2"
 pydantic-settings = "^2.0.3"
-python = ">=3.10,<3.13"
+python = ">=3.10"
 pyyaml = "^6.0.1"
 rich = "^13.6.0"
 scrapy = "^2.11.0"

--- a/projects/ecoindex_compute/pyproject.toml
+++ b/projects/ecoindex_compute/pyproject.toml
@@ -6,9 +6,8 @@ description = "Ecoindex module provides a simple way to measure the Ecoindex sco
 authors = ['Vincent Vatelot <vincent.vatelot@ik.me>']
 license = "Creative Commons BY-NC-ND"
 homepage = "http://www.ecoindex.fr"
-repository = "https://github.com/cnumr/ecoindex_python"
+repository = "https://github.com/cnumr/EcoIndex_python"
 include = ["LICENSE"]
-
 packages = [
     { include = "ecoindex/compute", from = "../../components" },
     { include = "ecoindex/data", from = "../../components" },

--- a/projects/ecoindex_scraper/pyproject.toml
+++ b/projects/ecoindex_scraper/pyproject.toml
@@ -6,7 +6,7 @@ description = "Ecoindex_scraper module provides a way to scrape data from given 
 authors = ['Vincent Vatelot <vincent.vatelot@ik.me>']
 license = "Creative Commons BY-NC-ND"
 homepage = "http://www.ecoindex.fr"
-repository = "https://github.com/cnumr/ecoindex_scrap_python"
+repository = "https://github.com/cnumr/EcoIndex_python"
 include = ["LICENSE"]
 packages = [
     { include = "ecoindex/compute", from = "../../components" },


### PR DESCRIPTION
Hello, I saw on pypi packages that the URL is not correct

Changed the repository URL to https://github.com/cnumr/EcoIndex_python on all 4 projects
Also uniformized a bit the pyproject files to be almost identical