### PR TITLE
fix: extend Python version support to 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ecoindex-monorepo"
 version = "0.1.0"
 description = ""
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<4"
 authors = [{ name = "Vincent Vatelot", email = "vincent.vatelot@ik.me" }]
 dependencies = [
     "aiofile>=3.8.8",


### PR DESCRIPTION
## Summary

- Relax `requires-python` from `>=3.10,<3.13` to `>=3.10,<4`
- The package works fine on Python 3.13 and 3.14, but the upper bound prevents installation without workarounds (`--ignore-requires-python`)

## Context

We use ecoindex-monorepo in a project running Python 3.14 and had to add `pip config set global.ignore-requires-python true` as a workaround during Docker builds. This PR removes the need for such hacks.

## Test plan

- [x] Verified the package installs and works correctly on Python 3.14